### PR TITLE
Adding "some" higher-order functions for collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# json-logic-js
+# json-logic-js-enhanced
+
+Enhanced version of json-logic-js, with higher order operators like map, filter, every and some.
+
+---
 
 This parser accepts [JsonLogic](http://jsonlogic.com) rules and executes them in JavaScript.
 
@@ -124,4 +128,4 @@ curl -O https://raw.githubusercontent.com/jwadhams/json-logic-js/master/logic.js
 
 This library makes use of `Array.map` and `Array.reduce`, so it's not *exactly* Internet Explorer 8 friendly.
 
-If you want to use JsonLogic *and* support deprecated browsers, you could easily use [BabelJS's polyfill](https://babeljs.io/docs/usage/polyfill/) or directly incorporate the polyfills documented on MDN for [map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce). 
+If you want to use JsonLogic *and* support deprecated browsers, you could easily use [BabelJS's polyfill](https://babeljs.io/docs/usage/polyfill/) or directly incorporate the polyfills documented on MDN for [map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce).

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,10 @@
 {
-  "name": "json-logic-js",
-  "version": "1.0.9",
-  "homepage": "https://github.com/jwadhams/json-logic-js",
+  "name": "json-logic-js-enhanced",
+  "version": "1.1.0",
+  "homepage": "https://github.com/kakkoyun/json-logic-js",
   "authors": [
-    "Jeremy Wadhams <jwadhams@dealerinspire.com>"
+    "Jeremy Wadhams <jwadhams@dealerinspire.com> (http://jsonlogic.com)",
+    "Kemal Akkoyun <kakkoyun@gmail.com>"
   ],
   "description": "Serialize complex logic in JSON, run it in JavaScript",
   "main": "logic.js",

--- a/logic.js
+++ b/logic.js
@@ -19,13 +19,13 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     return Array.prototype.slice.call(args);
   };
 
-  if ( ! Array.isArray) {
+  if (!Array.isArray) {
     Array.isArray = function(arg) {
       return Object.prototype.toString.call(arg) === "[object Array]";
     };
   }
 
-  if( ! Array.unique) {
+  if(!Array.unique) {
     /* eslint-disable no-extend-native */
     Array.prototype.unique = function() {
       var a = [];
@@ -38,7 +38,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     };
   }
 
-  if( ! Array.flatten) {
+  if(!Array.flatten) {
     Array.prototype.flatten = function() {
       return this.reduce(function(acc, elem) {
         return Array.isArray(elem)
@@ -91,11 +91,11 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       return (b.indexOf(a) !== -1);
     },
     "map": function(a, b) {
+      if(typeof a.indexOf === "function") return false;
       if(typeof b.indexOf === "undefined") return false;
       try {
-        var logic = JSON.parse(a);
         return Array.prototype.map.call(b, function(val) {
-          return jsonLogic.apply(logic, val);
+          return jsonLogic.apply(a(val));
         });
       } catch(exception) {
         console.log(exception);
@@ -103,11 +103,11 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       }
     },
     "filter": function(a, b) {
+      if(typeof a.indexOf === "function") return false;
       if(typeof b.indexOf === "undefined") return false;
       try {
-        var logic = JSON.parse(a);
         return Array.prototype.filter.call(b, function(val) {
-          return jsonLogic.truthy(jsonLogic.apply(logic, val));
+          return jsonLogic.truthy(a(val));
         });
       } catch(exception) {
         console.log(exception);
@@ -269,14 +269,14 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       given one parameter, evaluate and return it. (it's an Else and all the If/ElseIf were false)
       given 0 parameters, return NULL (not great practice, but there was no Else)
       */
-      for(i = 0; i < values.length - 1; i += 2) {
+      for (i = 0; i < values.length - 1; i += 2) {
         if( jsonLogic.truthy( jsonLogic.apply(values[i], data) ) ) {
           return jsonLogic.apply(values[i+1], data);
         }
       }
-      if(values.length === i+1) return jsonLogic.apply(values[i], data);
+      if (values.length === i+1) return jsonLogic.apply(values[i], data);
       return null;
-    }else if(op === "and") { // Return first falsy, or last
+    } else if(op === "and") { // Return first falsy, or last
       for(i=0; i < values.length; i+=1) {
         current = jsonLogic.apply(values[i], data);
         if( ! jsonLogic.truthy(current)) {
@@ -284,7 +284,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
         }
       }
       return current; // Last
-    }else if(op === "or") {// Return first truthy, or last
+    } else if(op === "or") {// Return first truthy, or last
       for(i=0; i < values.length; i+=1) {
         current = jsonLogic.apply(values[i], data);
         if( jsonLogic.truthy(current) ) {
@@ -292,14 +292,16 @@ http://ricostacruz.com/cheatsheets/umdjs.html
         }
       }
       return current; // Last
+    } else if(op == "=>") {
+      return function(capturedData) {
+        return jsonLogic.apply(values[0], capturedData);
+      };
     }
-
 
     // Everyone else gets immediate depth-first recursion
     values = values.map(function(val) {
       return jsonLogic.apply(val, data);
     });
-
 
     if(typeof operations[op] === "function") {
       return operations[op].apply(data, values);

--- a/logic.js
+++ b/logic.js
@@ -105,7 +105,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       try {
         var logic = JSON.parse(a)
         return Array.prototype.filter.call(b, function(val) {
-          return jsonLogic.apply(logic, val);
+          return jsonLogic.truthy(jsonLogic.apply(logic, val));
         });
       } catch(exception) {
         console.log(exception);

--- a/logic.js
+++ b/logic.js
@@ -88,6 +88,18 @@ http://ricostacruz.com/cheatsheets/umdjs.html
         return false;
       }
     },
+    "filter": function(a, b) {
+      if(typeof b.indexOf === "undefined") return false;
+      try {
+        var logic = JSON.parse(a)
+        return Array.prototype.filter.call(b, function(val) {
+          return jsonLogic.apply(logic, val);
+        });
+      } catch(exception) {
+        console.log(exception);
+        return false;
+      }
+    },
     "cat": function() {
       return Array.prototype.join.call(
         Array.prototype.reduce.call(arguments, function(a, b) {

--- a/logic.js
+++ b/logic.js
@@ -89,16 +89,30 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       }
     },
     "cat": function() {
-      return Array.prototype.join.call(arguments, "");
+      return Array.prototype.join.call(
+        Array.prototype.reduce.call(arguments, function(a, b) {
+          return a.concat(b);
+        })
+        , 
+        "");
     },
     "+": function() {
-      return Array.prototype.reduce.call(arguments, function(a, b) {
-        return parseFloat(a, 10) + parseFloat(b, 10);
-      }, 0);
+      return Array.prototype.reduce.call(
+        Array.prototype.reduce.call(arguments, function(a, b) {
+          return a.concat(b);
+        }), 
+        function(a, b) {
+          return parseFloat(a, 10) + parseFloat(b, 10);
+      }, 
+      0);
     },
     "*": function() {
-      return Array.prototype.reduce.call(arguments, function(a, b) {
-        return parseFloat(a, 10) * parseFloat(b, 10);
+      return Array.prototype.reduce.call(
+        Array.prototype.reduce.call(arguments, function(a, b) {
+          return a.concat(b);
+        }), 
+        function(a, b) {
+          return parseFloat(a, 10) * parseFloat(b, 10);
       });
     },
     "-": function(a, b) {
@@ -116,10 +130,20 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       }
     },
     "min": function() {
-      return Math.min.apply(this, arguments);
+      return Math.min.apply(
+        this, 
+        Array.prototype.reduce.call(arguments, function(a, b) {
+          return a.concat(b);
+        })
+      );
     },
     "max": function() {
-      return Math.max.apply(this, arguments);
+      return Math.max.apply(
+        this, 
+        Array.prototype.reduce.call(arguments, function(a, b) {
+          return a.concat(b);
+        })
+      );
     },
     "merge": function() {
       return Array.prototype.reduce.call(arguments, function(a, b) {

--- a/logic.js
+++ b/logic.js
@@ -17,7 +17,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
 
   var toArray = function(args) {
     return Array.prototype.slice.call(args);
-  }
+  };
 
   if ( ! Array.isArray) {
     Array.isArray = function(arg) {
@@ -39,11 +39,13 @@ http://ricostacruz.com/cheatsheets/umdjs.html
   }
 
   if( ! Array.flatten) {
-   Array.prototype.flatten = function() {
+    Array.prototype.flatten = function() {
       return this.reduce(function(acc, elem) {
-        return Array.isArray(elem) ? acc.concat(elem.flatten()) : acc.concat(elem);
-    }, []);
-   };
+        return Array.isArray(elem)
+            ? acc.concat(elem.flatten())
+            : acc.concat(elem);
+      }, []);
+    };
   }
 
   var jsonLogic = {};
@@ -91,7 +93,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     "map": function(a, b) {
       if(typeof b.indexOf === "undefined") return false;
       try {
-        var logic = JSON.parse(a)
+        var logic = JSON.parse(a);
         return Array.prototype.map.call(b, function(val) {
           return jsonLogic.apply(logic, val);
         });
@@ -103,7 +105,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     "filter": function(a, b) {
       if(typeof b.indexOf === "undefined") return false;
       try {
-        var logic = JSON.parse(a)
+        var logic = JSON.parse(a);
         return Array.prototype.filter.call(b, function(val) {
           return jsonLogic.truthy(jsonLogic.apply(logic, val));
         });
@@ -117,18 +119,18 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     },
     "+": function() {
       return Array.prototype.reduce.call(
-        toArray(arguments).flatten(), 
+        toArray(arguments).flatten(),
         function(a, b) {
           return parseFloat(a, 10) + parseFloat(b, 10);
-      }, 
+        },
       0);
     },
     "*": function() {
       return Array.prototype.reduce.call(
-        toArray(arguments).flatten(), 
+        toArray(arguments).flatten(),
         function(a, b) {
           return parseFloat(a, 10) * parseFloat(b, 10);
-      });
+        });
     },
     "-": function(a, b) {
       if(b === undefined) {

--- a/logic.js
+++ b/logic.js
@@ -76,6 +76,18 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       if(typeof b.indexOf === "undefined") return false;
       return (b.indexOf(a) !== -1);
     },
+    "map": function(a, b) {
+      if(typeof b.indexOf === "undefined") return false;
+      try {
+        var logic = JSON.parse(a)
+        return Array.prototype.map.call(b, function(val) {
+          return jsonLogic.apply(logic, val);
+        });
+      } catch(exception) {
+        console.log(exception);
+        return false;
+      }
+    },
     "cat": function() {
       return Array.prototype.join.call(arguments, "");
     },

--- a/logic.js
+++ b/logic.js
@@ -15,6 +15,10 @@ http://ricostacruz.com/cheatsheets/umdjs.html
   "use strict";
   /* globals console:false */
 
+  var toArray = function(args) {
+    return Array.prototype.slice.call(args);
+  }
+
   if ( ! Array.isArray) {
     Array.isArray = function(arg) {
       return Object.prototype.toString.call(arg) === "[object Array]";
@@ -32,6 +36,14 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       }
       return a;
     };
+  }
+
+  if( ! Array.flatten) {
+   Array.prototype.flatten = function() {
+      return this.reduce(function(acc, elem) {
+        return Array.isArray(elem) ? acc.concat(elem.flatten()) : acc.concat(elem);
+    }, []);
+   };
   }
 
   var jsonLogic = {};
@@ -101,18 +113,11 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       }
     },
     "cat": function() {
-      return Array.prototype.join.call(
-        Array.prototype.reduce.call(arguments, function(a, b) {
-          return a.concat(b);
-        })
-        , 
-        "");
+      return Array.prototype.join.call(toArray(arguments).flatten(), "");
     },
     "+": function() {
       return Array.prototype.reduce.call(
-        Array.prototype.reduce.call(arguments, function(a, b) {
-          return a.concat(b);
-        }), 
+        toArray(arguments).flatten(), 
         function(a, b) {
           return parseFloat(a, 10) + parseFloat(b, 10);
       }, 
@@ -120,9 +125,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     },
     "*": function() {
       return Array.prototype.reduce.call(
-        Array.prototype.reduce.call(arguments, function(a, b) {
-          return a.concat(b);
-        }), 
+        toArray(arguments).flatten(), 
         function(a, b) {
           return parseFloat(a, 10) * parseFloat(b, 10);
       });
@@ -142,20 +145,10 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       }
     },
     "min": function() {
-      return Math.min.apply(
-        this, 
-        Array.prototype.reduce.call(arguments, function(a, b) {
-          return a.concat(b);
-        })
-      );
+      return Math.min.apply(this, toArray(arguments).flatten());
     },
     "max": function() {
-      return Math.max.apply(
-        this, 
-        Array.prototype.reduce.call(arguments, function(a, b) {
-          return a.concat(b);
-        })
-      );
+      return Math.max.apply(this, toArray(arguments).flatten());
     },
     "merge": function() {
       return Array.prototype.reduce.call(arguments, function(a, b) {

--- a/logic.js
+++ b/logic.js
@@ -92,7 +92,9 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     },
     "map": function(a, b) {
       if(typeof a.indexOf === "function") return false;
-      if(typeof b.indexOf === "undefined") return false;
+      if(typeof b === "undefined" || typeof b.indexOf === "undefined") {
+        return false;
+      }
       try {
         return Array.prototype.map.call(b, function(val) {
           return jsonLogic.apply(a(val));
@@ -104,11 +106,47 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     },
     "filter": function(a, b) {
       if(typeof a.indexOf === "function") return false;
-      if(typeof b.indexOf === "undefined") return false;
+      if(typeof b === "undefined" || typeof b.indexOf === "undefined") {
+        return false;
+      }
       try {
         return Array.prototype.filter.call(b, function(val) {
           return jsonLogic.truthy(a(val));
         });
+      } catch(exception) {
+        console.log(exception);
+        return false;
+      }
+    },
+    "every": function(a, b) {
+      if(typeof a.indexOf === "function") return false;
+      if(typeof b === "undefined" || typeof b.indexOf === "undefined") {
+        return false;
+      }
+      try {
+        for(i=0; i < b.length; i+=1) {
+          if(!jsonLogic.truthy(a(b[i]))) {
+            return false;
+          }
+        }
+        return true;
+      } catch(exception) {
+        console.log(exception);
+        return false;
+      }
+    },
+    "some": function(a, b) {
+      if(typeof a.indexOf === "function") return false;
+      if(typeof b === "undefined" || typeof b.indexOf === "undefined") {
+        return false;
+      }
+      try {
+        for(i=0; i < b.length; i+=1) {
+          if(jsonLogic.truthy(a(b[i]))) {
+            return true;
+          }
+        }
+        return false;
       } catch(exception) {
         console.log(exception);
         return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "json-logic-js",
-  "version": "1.0.9",
+  "name": "json-logic-js-enhanced",
+  "version": "1.1.0",
   "description": "Build complex rules, serialize them as JSON, and execute them in JavaScript",
   "main": "logic.js",
   "directories": {
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jwadhams/json-logic-js.git"
+    "url": "git+https://github.com/kakkoyun/json-logic-js.git"
   },
   "keywords": [
     "json",
@@ -27,10 +27,13 @@
     "jsonlogic",
     "rules"
   ],
-  "author": "Jeremy Wadhams <jwadhams@dealerinspire.com> (http://jsonlogic.com)",
+  "authors": [
+    "Jeremy Wadhams <jwadhams@dealerinspire.com> (http://jsonlogic.com)",
+    "Kemal Akkoyun <kakkoyun@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jwadhams/json-logic-js/issues"
+    "url": "https://github.com/kakkoyun/json-logic-js/issues"
   },
-  "homepage": "https://github.com/jwadhams/json-logic-js#readme"
+  "homepage": "https://github.com/kakkoyun/json-logic-js#readme"
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -270,3 +270,46 @@ QUnit.test("Control structures don't eval depth-first", function(assert) {
   jsonLogic.apply({"or": [{"push": [true]}, {"push": [true]}]});
   assert.deepEqual(i, [true]);
 });
+
+QUnit.test( "Fat Arrow operator don't eval depth-first", function(assert) {
+  i = [];
+  jsonLogic.apply({ "=>": { ">=": [{ "var": "value" }, 2] } });
+  assert.deepEqual(i, []);
+});
+
+QUnit.test( "Using high order functions on collections", function(assert) {
+  var data = {
+    "data": [
+      {
+        "name": "one",
+        "value": 1,
+      },
+      {
+        "name": "two",
+        "value": 2,
+      },
+    ],
+  };
+  var logic = {};
+
+  logic = {"+": {"map": [{"=>": {"var": "value"}}, {"var": "data"}]}};
+  assert.deepEqual(jsonLogic.apply(logic, data), 3);
+
+  logic = {"min": {"map": [{"=>": {"var": "value"}}, {"var": "data"}]}};
+  assert.deepEqual(jsonLogic.apply(logic, data), 1);
+
+  logic = {"max": {"map": [{"=>": {"var": "value"}}, {"var": "data"}]}};
+  assert.deepEqual(jsonLogic.apply(logic, data), 2);
+
+  logic = {"in": ["one", {"map": [{"=>": {"var": "name"}}, {"var": "data"}]}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), true);
+
+  logic = {"map": [{"=>": {"var": "name"}}, {"var": "data"}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), ["one", "two"]);
+
+  logic = {"map": [{"=>": {"var": "value"}}, {"var": "data"}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), [1, 2]);
+
+  logic = {"filter": [{"=>": {">=": [{"var": "value"}, 2]}}, {"var": "data"}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), [{name: "two", value: 2}]);
+});

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -310,6 +310,24 @@ QUnit.test( "Using high order functions on collections", function(assert) {
   logic = {"map": [{"=>": {"var": "value"}}, {"var": "data"}]};
   assert.deepEqual(jsonLogic.apply(logic, data), [1, 2]);
 
+  logic = {"filter": [{"=>": {">=": [{"var": "value"}, 3]}}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), false);
   logic = {"filter": [{"=>": {">=": [{"var": "value"}, 2]}}, {"var": "data"}]};
   assert.deepEqual(jsonLogic.apply(logic, data), [{name: "two", value: 2}]);
+  logic = {"filter": [{"=>": {">=": [{"var": "value"}, 3]}}, {"var": "data"}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), []);
+
+  logic = {"every": [{"=>": {">=": [{"var": "value"}, 1]}}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), false);
+  logic = {"every": [{"=>": {">=": [{"var": "value"}, 1]}}, {"var": "data"}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), true);
+  logic = {"every": [{"=>": {">=": [{"var": "value"}, 2]}}, {"var": "data"}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), false);
+
+  logic = {"some": [{"=>": {">=": [{"var": "value"}, 2]}}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), false);
+  logic = {"some": [{"=>": {">=": [{"var": "value"}, 2]}}, {"var": "data"}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), true);
+  logic = {"some": [{"=>": {">=": [{"var": "value"}, 3]}}, {"var": "data"}]};
+  assert.deepEqual(jsonLogic.apply(logic, data), false);
 });


### PR DESCRIPTION
Adds `map`, `filter`, `some`, `every` operation support for collections.

I don't know if you prefer approach that you introduced in #15 but to achieve deferred execution, `=>` operator introduced, so function can be embedded directly in specs. 

I tried to respect conventions of code, using ESLint, pardon me any inconvenient changes.
It would be great if you suggest any refinements or improvements.
I can implement same functionality for Ruby, add documentation if needed. I wrote small number of tests, I can improve them also.
