### PR TITLE
Allow for distinct JSONLogic instances

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -11,7 +11,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
   } else {
     root.jsonLogic = factory();
   }
-}(this, function() {
+}(this, function createInstance() {
   "use strict";
   /* globals console:false */
 
@@ -459,6 +459,8 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     // Not logic, not array, not a === match for rule.
     return false;
   };
+
+  jsonLogic.createInstance = createInstance;
 
   return jsonLogic;
 }));

--- a/logic.js
+++ b/logic.js
@@ -11,7 +11,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
   } else {
     root.jsonLogic = factory();
   }
-}(this, function createInstance() {
+}(this, function JSONLogic() {
   "use strict";
   /* globals console:false */
 
@@ -460,7 +460,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     return false;
   };
 
-  jsonLogic.createInstance = createInstance;
+  jsonLogic.JSONLogic = JSONLogic;
 
   return jsonLogic;
 }));


### PR DESCRIPTION
This change exposes the JSONLogic factory function so that multiple independent instances of JSONLogic can be instantiated at once. For example:

```javascript
// The module itself still acts like a JSONLogic instance.
const defaultInstance = require('json-logic-js');
defaultInstance.apply({"<": [2, 3]});

// However, now you can create additional instances of
// JSONLogic as well.  Each instance can have its own
// custom operators.
const myInstance = new defaultInstance.JSONLogic();

myInstance.add_operation("join", function(ary, glue) {
  return ary.join(glue);
});

myInstance.apply({"join": [ ["foo", "bar"], ","] });
```