### PR TITLE
Fixed issues where scopedData is null

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -318,7 +318,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       );
 
     }else if(op === "all") {
-      scopedData = jsonLogic.apply(values[0], data);
+      scopedData = jsonLogic.apply(values[0], data) || [];
       scopedLogic = values[1];
       // All of an empty set is false. Note, some and none have correct fallback after the for loop
       if( ! scopedData.length) {


### PR DESCRIPTION
In rule like this 

```
{"all" : [   {
  var: 'current_value'
}, {
  in: [
    {
      "var":""
    },
    [
      0,
      'A',
      'B',
      'C',
      ' '
    ]
  ]
} ]}
```

If current_value is undefined (null) I'll get error Cannot read property 'length' of null