### PR TITLE
fix: don't treat falsy data as no data

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -218,7 +218,9 @@ http://ricostacruz.com/cheatsheets/umdjs.html
       return logic;
     }
 
-    data = data || {};
+    if (data === null || data === undefined) {
+      data = {};
+    }
 
     var op = jsonLogic.get_operator(logic);
     var values = logic[op];


### PR DESCRIPTION
When calling `apply` with data that is falsy, it's treated the same as `null` or `undefined` and defaults to en empty object.

Current behaviour:
```js
jsonLogic.apply({ '==': [{ var: "" }, 0] }, 0);
// false
```

Expected behaviour after this fix:
```js
jsonLogic.apply({ '==': [{ var: "" }, 0] }, 0);
// true
```