### PR TITLE
Feature/ Controlled Execution

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -37,6 +37,7 @@ http://ricostacruz.com/cheatsheets/umdjs.html
   }
 
   var jsonLogic = {};
+  var runOperationAsControlled = {};
   var operations = {
     "==": function(a, b) {
       return a == b;
@@ -348,6 +349,8 @@ http://ricostacruz.com/cheatsheets/umdjs.html
         }
       }
       return false; // None were truthy
+    } else if (runOperationAsControlled[op]) {
+      return operations[op](values, data, jsonLogic);
     }
 
     // Everyone else gets immediate depth-first recursion
@@ -404,12 +407,16 @@ http://ricostacruz.com/cheatsheets/umdjs.html
     return arrayUnique(collection);
   };
 
-  jsonLogic.add_operation = function(name, code) {
+  jsonLogic.add_operation = function(name, code, options) {
     operations[name] = code;
+
+    var controlledExecution = Boolean(options && options.controlledExecution);
+    runOperationAsControlled[name] = controlledExecution;
   };
 
   jsonLogic.rm_operation = function(name) {
     delete operations[name];
+    delete runOperationAsControlled[name];
   };
 
   jsonLogic.rule_like = function(rule, pattern) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -310,14 +310,14 @@ QUnit.module('basic', () => {
 
   QUnit.test("Expanding functionality with add_operator - controlledExecution", function(assert) {
     // assert that controlled execution doesn't do pre-evaluation
-    var customOp = function(values, data, jsonLogic) {
-      return jsonLogic.apply(values[0], data);
+    var customOp = function(values) {
+      return values[0];
     }
 
     jsonLogic.add_operation('customOp', customOp, { controlledExecution: true });
 
-    assert.deepEqual(jsonLogic.apply({ customOp: [{ "var": "" }, { "var": "test" }]}, { test: 123 }), { test: 123 });
-    assert.deepEqual(jsonLogic.apply({ customOp: [{ "var": "test" }, { "var": "" }]}, { test: 123 }), 123);
+    assert.deepEqual(jsonLogic.apply({ customOp: [{ "var": "" }, { "var": "test" }]}, { test: 123 }), { var: "" });
+    assert.deepEqual(jsonLogic.apply({ customOp: [{ "var": "test" }, { "var": "" }]}, { test: 123 }), { var: "test" });
 
     // assert that controlled execution custom operators can be removed as normal
     jsonLogic.rm_operation('customOp');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -307,4 +307,49 @@ QUnit.module('basic', () => {
     jsonLogic.apply({"or": [{"push": [true]}, {"push": [true]}]});
     assert.deepEqual(i, [true]);
   });
+
+  QUnit.test("Expanding functionality with add_operator - controlledExecution", function(assert) {
+    // assert that controlled execution doesn't do pre-evaluation
+    var customOp = function(values, data, jsonLogic) {
+      return jsonLogic.apply(values[0], data);
+    }
+
+    jsonLogic.add_operation('customOp', customOp, { controlledExecution: true });
+
+    assert.deepEqual(jsonLogic.apply({ customOp: [{ "var": "" }, { "var": "test" }]}, { test: 123 }), { test: 123 });
+    assert.deepEqual(jsonLogic.apply({ customOp: [{ "var": "test" }, { "var": "" }]}, { test: 123 }), 123);
+
+    // assert that controlled execution custom operators can be removed as normal
+    jsonLogic.rm_operation('customOp');
+
+    assert.throws(() => jsonLogic.apply({ customOp: [] }), Error, "Unrecognized operation customOp");
+
+    // assert that controlled-execution custom operators have access to jsonLogic object
+    // and can run on external data
+    const externalData = {
+      specialReference: 'external reference'
+    };
+    customOp = function(values, data, jsonLogic) {
+      return jsonLogic.apply(values[0], externalData);
+    }
+
+    jsonLogic.add_operation('customOp', customOp, { controlledExecution: true });
+
+    assert.deepEqual(jsonLogic.apply({ customOp: [{ var: "specialReference" }] }, { specialReference: 'pre-evaluation value' }), 'external reference');
+
+    // assert that operators are added with normal functionality when options is omitted
+    jsonLogic.add_operation('customOp', customOp);
+
+    assert.throws(() => jsonLogic.apply({ customOp: [{ var: "specialReference" }] }, { specialReference: 'pre-evaluation value' }), TypeError, "Cannot read property 'apply' of undefined");
+
+    // assert that adding a custom operator without controlled-execution still 
+    // results in pre-evaluation
+    customOp = function(value) {
+      return value;
+    }
+
+    jsonLogic.add_operation('customOp', customOp);
+
+    assert.deepEqual(jsonLogic.apply({ customOp: [{ var: "specialReference" }] }, { specialReference: 'pre-evaluation value' }), 'pre-evaluation value');
+  });
 });


### PR DESCRIPTION
**Changes:**
- Added `controlledExecution` option on `add_operation` function
- Added unit tests `controlledExecution`

**Description**

This PR adds functionality so that when registering a custom operator with the `add_operator` method, you can now pass in a third param `options` with the property `controlledExecution`. This option allows you to specify how your operator should be treated during evaluation and also prevents all nested parameters to the operator from being pre-evaluated.

**Links**
https://github.com/jwadhams/json-logic-js/issues/116