### PR TITLE
Document TypeScript support in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ If that doesn't suit you, and you want to manage updates yourself, the entire li
 curl -O https://raw.githubusercontent.com/jwadhams/json-logic-js/master/logic.js
 ```
 
+### TypeScript Support
+
+In addition to installing the `json-logic-js` package you may also install the types:
+
+```bash
+npm install --save-dev @types/json-logic-js
+```
+
+You may import the package like so:
+
+```ts
+import * as jsonLogic from 'json-logic-js';
+```
+
 ## Examples
 
 ### Simple


### PR DESCRIPTION
Fixes https://github.com/jwadhams/json-logic-js/issues/108

This PR explains that TypeScript definitions can be installed. Additionally, it shows an example of how to import JSON Logic into a TypeScript file.

I searched around for examples of how other libs explain TypeScript support, and I was surprised to not find much. I am probably not looking in the right place.

However, I did find this example: https://github.com/luin/ioredis#quick-start.